### PR TITLE
Fix: POST new proposal 

### DIFF
--- a/pages/api/proposals/index.ts
+++ b/pages/api/proposals/index.ts
@@ -41,7 +41,7 @@ export default withAuth(async (req, res, session) => {
           name,
           author: session.address as string,
           coAuthors,
-          dateProposal,
+          dateProposal: new Date(dateProposal),
           championshipTeam,
           leadershipSponsor,
           summary,


### PR DESCRIPTION
1 line code fix to ensure that `dateProposal` is proper type before post request for new proposal.