### PR TITLE
Feature: Leadership Sponsor Dropdown List Field in New Proposal Form 

### DIFF
--- a/components/proposalForm.tsx
+++ b/components/proposalForm.tsx
@@ -21,18 +21,31 @@ import { Proposal } from "@prisma/client";
 
 const ProposalForm = () => {
   const router = useRouter();
+
   const {
     handleSubmit,
     register,
     formState: { errors },
   } = useForm<Proposal>();
+
   const { createProposal, isLoading } = useCreateProposal();
-  const { leadershipSponsors } = useLeadershipSponsor();
+
   const onSubmit = (proposal: Proposal) => {
     createProposal(proposal, { onSuccess: () => router.push("/") });
   };
 
-  console.log(leadershipSponsors, "LEADERSHIP");
+  const { leadershipSponsors } = useLeadershipSponsor();
+
+  let selectOptions: any[] = [];
+  if (leadershipSponsors) {
+    selectOptions = leadershipSponsors?.map((idx: any) => (
+      <option value="x" key={idx}>
+        x
+      </option>
+    ));
+  }
+  // let selectOptions = ["Chen Zur", "Arwin Holmes"];
+  // console.log(selectOptions);
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
@@ -76,7 +89,7 @@ const ProposalForm = () => {
 
         <FormControl>
           <FormLabel>Leadership Sponsor:</FormLabel>
-          <Select placeholder="Select Leadership Sponsor"></Select>
+          <Select placeholder="Select option">{...selectOptions}</Select>
           <Input {...register("leadershipSponsor")} autoComplete="off" />
         </FormControl>
 

--- a/components/proposalForm.tsx
+++ b/components/proposalForm.tsx
@@ -10,11 +10,13 @@ import {
   Spacer,
   Textarea,
   VStack,
+  Select,
 } from "@chakra-ui/react";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
 import { useRouter } from "next/router";
 import { useCreateProposal } from "lib/useProposals";
+import { useLeadershipSponsor } from "lib/useLeadershipSponsor";
 import { Proposal } from "@prisma/client";
 
 const ProposalForm = () => {
@@ -25,9 +27,12 @@ const ProposalForm = () => {
     formState: { errors },
   } = useForm<Proposal>();
   const { createProposal, isLoading } = useCreateProposal();
+  const { leadershipSponsors } = useLeadershipSponsor();
   const onSubmit = (proposal: Proposal) => {
     createProposal(proposal, { onSuccess: () => router.push("/") });
   };
+
+  console.log(leadershipSponsors, "LEADERSHIP");
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
@@ -71,9 +76,7 @@ const ProposalForm = () => {
 
         <FormControl>
           <FormLabel>Leadership Sponsor:</FormLabel>
-          <FormHelperText>
-            Enter full name of Leadership Sponsor.
-          </FormHelperText>
+          <Select placeholder="Select Leadership Sponsor"></Select>
           <Input {...register("leadershipSponsor")} autoComplete="off" />
         </FormControl>
 

--- a/components/proposalForm.tsx
+++ b/components/proposalForm.tsx
@@ -26,26 +26,25 @@ const ProposalForm = () => {
     handleSubmit,
     register,
     formState: { errors },
-  } = useForm<Proposal>();
+  } = useForm<Proposal>({ mode: "onSubmit" });
 
   const { createProposal, isLoading } = useCreateProposal();
 
   const onSubmit = (proposal: Proposal) => {
+    console.log("On submit", proposal);
     createProposal(proposal, { onSuccess: () => router.push("/") });
   };
 
   const { leadershipSponsors } = useLeadershipSponsor();
 
-  let selectOptions: any[] = [];
+  let selectOptions: JSX.Element[] = [];
   if (leadershipSponsors) {
-    selectOptions = leadershipSponsors?.map((idx: any) => (
-      <option value="x" key={idx}>
-        x
+    selectOptions = leadershipSponsors?.map((val) => (
+      <option value={val.name} key={val.id}>
+        {val.name}
       </option>
     ));
   }
-  // let selectOptions = ["Chen Zur", "Arwin Holmes"];
-  // console.log(selectOptions);
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
@@ -89,8 +88,12 @@ const ProposalForm = () => {
 
         <FormControl>
           <FormLabel>Leadership Sponsor:</FormLabel>
-          <Select placeholder="Select option">{...selectOptions}</Select>
-          <Input {...register("leadershipSponsor")} autoComplete="off" />
+          <Select
+            placeholder="Select option"
+            {...register("leadershipSponsor")}
+          >
+            {selectOptions}
+          </Select>
         </FormControl>
 
         <FormControl isRequired>
@@ -152,7 +155,9 @@ const ProposalForm = () => {
             Save
           </Button>
           <Link href="#" passHref>
-            <Button colorScheme="blue">Submit for RFC</Button>
+            <Button isLoading={isLoading} colorScheme="blue">
+              Submit for RFC
+            </Button>
           </Link>
         </Flex>
       </VStack>

--- a/lib/useLeadershipSponsor.ts
+++ b/lib/useLeadershipSponsor.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import { LeadershipSponsor } from "@prisma/client";
+import { stringify } from "querystring";
 
 export function useLeadershipSponsor() {
   const { data: leadershipSponsors, isLoading } = useQuery(

--- a/lib/useLeadershipSponsor.ts
+++ b/lib/useLeadershipSponsor.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { LeadershipSponsor } from "@prisma/client";
+
+export function useLeadershipSponsor() {
+  const { data: leadershipSponsors, isLoading } = useQuery(
+    ["leadershipSponsor"],
+    async () => {
+      const response = await axios.get<LeadershipSponsor[]>(
+        "/api/leadershipSponsor"
+      );
+      return response.data;
+    }
+  );
+  return { leadershipSponsors, isLoading };
+}

--- a/pages/api/leadershipSponsor/index.ts
+++ b/pages/api/leadershipSponsor/index.ts
@@ -1,0 +1,25 @@
+import { PrismaClient, ProposalStatus } from "@prisma/client";
+import { withAuth } from "lib/auth";
+
+const prisma = new PrismaClient();
+
+export default withAuth(async (req, res, session) => {
+  const { method } = req;
+
+  switch (method) {
+    case "GET":
+      try {
+        const leadershipSponsors = await prisma.leadershipSponsor.findMany();
+        return res.json(leadershipSponsors);
+      } catch (err) {
+        return res.status(500).json({
+          error: "Failed to get leadership",
+        });
+      }
+
+    default:
+      return res.status(405).json({
+        error: "Method Not Allowed",
+      });
+  }
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,17 +16,22 @@ enum ProposalStatus {
 }
 
 model Proposal {
-  id                  String @id @default(auto()) @map("_id") @db.ObjectId
-  name                String
-  author              String
-  coAuthors           String
-  dateProposal        DateTime @db.Date
-  championshipTeam    String
-  leadershipSponsor   String
-  summary             String
-  motivation          String
-  specifications      String
-  risks               String
-  successMetrics      String
-  status              ProposalStatus @default(DRAFT)
+  id                String         @id @default(auto()) @map("_id") @db.ObjectId
+  name              String
+  author            String
+  coAuthors         String
+  dateProposal      DateTime       @db.Date
+  championshipTeam  String
+  leadershipSponsor String
+  summary           String
+  motivation        String
+  specifications    String
+  risks             String
+  successMetrics    String
+  status            ProposalStatus @default(DRAFT)
+}
+
+model LeadershipSponsor {
+  id   String @id @default(auto()) @map("_id") @db.ObjectId
+  name String
 }


### PR DESCRIPTION
### Related Ticket:
https://eyblockchain.atlassian.net/browse/BIPT-49 

### Description:
Created drop down list in the new proposal form for the Leadership Sponsor field. This dropdown shows all the names for the US blockchain leadership. Names are stored as a db collection called LeadershipSponsor in the Mongodb remote db. 
<img width="1018" alt="image" src="https://user-images.githubusercontent.com/104782237/200172633-5dc01d34-1f09-4b16-ba24-a65011a67bbf.png">

### Instructions to View:
* [ ] cd eybc-bip
* [ ] git checkout kace/leadership-sponsor-field (ensure it is up to date with recent commits)
* [ ] npm run dev
* [ ] Pull up localhost:3000 in browser
* [ ] Click new proposal form button
* [ ] Click on Leadership Sponsor field to review dropdown. Dropdown should look exactly to the image above. 