### PR TITLE
Fix: Allow user to submit proposal with blank fields, UI refactor

### DIFF
--- a/components/proposalForm.tsx
+++ b/components/proposalForm.tsx
@@ -48,15 +48,11 @@ const ProposalForm = () => {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <VStack align="stretch" spacing={6}>
-        <FormControl isRequired isInvalid={!!errors.name}>
-          <FormLabel>BIP-#</FormLabel>
-          <InputGroup>
-            <InputLeftAddon>BIP-#:</InputLeftAddon>
-            <Input {...register("id", { required: true })} autoComplete="off" />
-          </InputGroup>
+        <FormControl isInvalid={!!errors.name}>
+          <FormLabel {...register("id")} ></FormLabel>
         </FormControl>
 
-        <FormControl>
+        <FormControl isRequired>
           <FormLabel>Title of BIP:</FormLabel>
           <Input {...register("name")} autoComplete="off" />
         </FormControl>

--- a/lib/useDrafts.ts
+++ b/lib/useDrafts.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import { Proposal } from "@prisma/client";
 

--- a/pages/api/proposals/index.ts
+++ b/pages/api/proposals/index.ts
@@ -36,12 +36,14 @@ export default withAuth(async (req, res, session) => {
           error: "Name and Summary are required fields",
         });
 
+      const dateOfProposal = dateProposal? new Date(dateProposal) : new Date();
+
       const proposal = await prisma.proposal.create({
         data: {
           name,
           author: session.address as string,
           coAuthors,
-          dateProposal: new Date(dateProposal),
+          dateProposal: dateOfProposal,
           championshipTeam,
           leadershipSponsor,
           summary,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,16 +18,16 @@ enum ProposalStatus {
 model Proposal {
   id                String         @id @default(auto()) @map("_id") @db.ObjectId
   name              String
-  author            String
-  coAuthors         String
+  author            String         @default("")
+  coAuthors         String         @default("")
   dateProposal      DateTime       @db.Date
-  championshipTeam  String
-  leadershipSponsor String
+  championshipTeam  String         @default("")
+  leadershipSponsor String         @default("")
   summary           String
-  motivation        String
-  specifications    String
-  risks             String
-  successMetrics    String
+  motivation        String         @default("")
+  specifications    String         @default("")
+  risks             String         @default("")
+  successMetrics    String         @default("")
   status            ProposalStatus @default(DRAFT)
 }
 


### PR DESCRIPTION
Related Ticket:

<https://eyblockchain.atlassian.net/browse/BIPT-54>

Description:
- Back-end: Refactored post request code in `proposals>index.ts` to only require `title` and `summary` parameters to enable a user to successfully create a new draft from the proposal form page. 
- Front end: Refactored Proposal form to remove `BIP-#` field and denote the correctly required fields

![image](https://user-images.githubusercontent.com/99047250/202012127-5f15bebb-64e7-425f-be6f-820f95360762.png)

Instructions to View:

 - cd eybc-bip
 - git pull
 - git checkout meag/bipt54-bug
 - npm run dev
 - Pull up localhost:3000 in browser
 - Click new proposal form button
 - fill out required fields
 - hit "Save" button
 - navigate to "Drafts" tab
 - newly created draft should be visible
 
 @aj-may this PR requires a prisma refresh in vercel